### PR TITLE
Add print.css to precompile

### DIFF
--- a/lib/spree_conekta/engine.rb
+++ b/lib/spree_conekta/engine.rb
@@ -31,6 +31,10 @@ module SpreeConekta
       app.config.spree.payment_methods << Spree::BillingIntegration::ConektaGateway::MonthlyPayment
     end
 
+    initializer 'spree_conekta.assets.precompile' do |app|
+      app.config.assets.precompile += %w( spree/backend/print.css )
+    end
+
     config.to_prepare &method(:activate).to_proc
   end
 end


### PR DESCRIPTION
- Add print.css to assets precompile list to prevent Rails 4.2.2 asset filtered error
- Rails version `4.2.2`

> Error

```
Sprockets::Rails::Helper::AssetFilteredError in Spree::Home#index
```

> Description

```
Asset filtered out and will not be served: add `Rails.application.config.assets.precompile += %w( spree/backend/print.css )` to `config/initializers/assets.rb` and restart your server
```